### PR TITLE
Implements NSTableView <> ResultsController Bridge

### DIFF
--- a/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
+++ b/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
@@ -2,6 +2,86 @@
 import Foundation
 import AppKit
 
-// TODO!
+
+// MARK: - ResultsTableAnimations: Defines the Animations to be applied during Table Update(s)
+//
+public struct ResultsTableAnimations {
+
+    /// TableViewRowAnimation to be applied during Delete OP's.
+    ///
+    public let delete: NSTableView.AnimationOptions = .effectFade
+
+    /// TableViewRowAnimation to be applied during Insert OP's.
+    ///
+    public let insert: NSTableView.AnimationOptions = .effectFade
+
+    /// TableViewRowAnimation to be applied during Move OP's.
+    ///
+    public let move: NSTableView.AnimationOptions = .effectFade
+
+    /// TableViewRowAnimation to be applied during Update OP's.
+    ///
+    public let update: NSTableView.AnimationOptions = .effectFade
+
+    /// Standard ResultsTableAnimations Settings
+    ///
+    public static let standard = ResultsTableAnimations()
+}
+
+
+// MARK: - NSTableView ResultsController Convenience Methods
+//
+extension NSTableView {
+
+    public func performBatchChanges(objectsChangeset: ResultsObjectsChangeset) {
+        beginUpdates()
+
+        performChanges(objectsChangeset: objectsChangeset)
+
+        endUpdates()
+    }
+
+    /// This API applies Section and Object Changesets over the receiver. Based on WWDC 2020 @ Labs Recommendations
+    /// - Note: This should be done during onDidChangeContent so that we're never in the middle of a NSManagedObjectContext.save()
+    ///
+    public func performChanges(objectsChangeset: ResultsObjectsChangeset, animations: ResultsTableAnimations = .standard) {
+        // [Step 1] Structural Changes: Delete OP(s)
+        if !objectsChangeset.deleted.isEmpty {
+            removeRows(at: objectsChangeset.deleted.toIndexSet, withAnimation: animations.delete)
+        }
+
+        if !objectsChangeset.inserted.isEmpty {
+            insertRows(at: objectsChangeset.inserted.toIndexSet, withAnimation: animations.insert)
+        }
+
+        // [Step 2] Content Changes: Move OP(s)
+        for (from, to) in objectsChangeset.moved {
+            removeRows(at: IndexSet(integer: from.item), withAnimation: animations.delete)
+            insertRows(at: IndexSet(integer: to.item), withAnimation: animations.insert)
+        }
+
+        // [Step 3] Content Changes: Update OP(s)
+        if !objectsChangeset.updated.isEmpty {
+            let allColumnIndexes = IndexSet(integersIn: Int.zero ..< numberOfColumns)
+            reloadData(forRowIndexes: objectsChangeset.updated.toIndexSet, columnIndexes: allColumnIndexes)
+        }
+    }
+}
+
+
+// MARK: - Array / IndexPath Internal Helpers
+//
+extension Array where Element == IndexPath {
+
+    var toIndexSet: IndexSet {
+        var output = IndexSet()
+        for indexPath in self {
+            output.insert(indexPath.item)
+        }
+
+        return output
+    }
+}
+
 
 #endif

--- a/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
+++ b/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
@@ -37,11 +37,9 @@ extension NSTableView {
     /// - Important: While we process this batch, no `NSTableViewDelegate` events will be fired, in order to prevent potential reentrant flows
     ///
     public func performBatchChanges(objectsChangeset: ResultsObjectsChangeset) {
-        performWithoutDelegateEvents {
-            beginUpdates()
-            performChanges(objectsChangeset: objectsChangeset)
-            endUpdates()
-        }
+        beginUpdates()
+        performChanges(objectsChangeset: objectsChangeset)
+        endUpdates()
     }
 
     /// This API applies Section and Object Changesets over the receiver. Based on WWDC 2020 @ Labs Recommendations
@@ -68,17 +66,6 @@ extension NSTableView {
             let allColumnIndexes = IndexSet(integersIn: Int.zero ..< numberOfColumns)
             reloadData(forRowIndexes: objectsChangeset.updated.toIndexSet, columnIndexes: allColumnIndexes)
         }
-    }
-
-    /// Performs without triggering NSTableViewDelegate calls
-    ///
-    private func performWithoutDelegateEvents(block: () -> Void) {
-        let oldDelegate = delegate
-        delegate = nil
-
-        block()
-
-        delegate = oldDelegate
     }
 }
 

--- a/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
+++ b/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
@@ -78,7 +78,7 @@ extension NSTableView {
 
         block()
 
-        delegate =oldDelegate
+        delegate = oldDelegate
     }
 }
 

--- a/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
+++ b/Sources/SimplenoteFoundation/ResultsController/Extensions/NSTableView+ResultsController.swift
@@ -15,10 +15,6 @@ public struct ResultsTableAnimations {
     ///
     public let insert: NSTableView.AnimationOptions = .effectFade
 
-    /// TableViewRowAnimation to be applied during Move OP's.
-    ///
-    public let move: NSTableView.AnimationOptions = .effectFade
-
     /// TableViewRowAnimation to be applied during Update OP's.
     ///
     public let update: NSTableView.AnimationOptions = .effectFade

--- a/Sources/SimplenoteFoundation/ResultsController/ResultsController.swift
+++ b/Sources/SimplenoteFoundation/ResultsController/ResultsController.swift
@@ -63,6 +63,10 @@ public class ResultsController<T: NSManagedObject> {
         }
     }
 
+    /// Closure to be executed before the results are changed.
+    ///
+    public var onWillChangeContent: (() -> Void)?
+
     /// Closure to be executed after the results are changed.
     ///
     public var onDidChangeContent: ((_ sections: ResultsSectionsChangeset, _ objects: ResultsObjectsChangeset) -> Void)?
@@ -158,6 +162,7 @@ private extension ResultsController {
     ///
     func setupDelegateWrapper() {
         internalDelegate.onWillChangeContent = { [weak self] in
+            self?.onWillChangeContent?()
             self?.resetPendingChangesets()
         }
 


### PR DESCRIPTION
### Details:
In this PR we're implementing an API capable of sync'ing ResultsController changesets against a NSTableView Instance.

cc @eshurakov (Thanks in advance!!)

### Test
Please refer to [this Simplenote macOS branch](https://github.com/Automattic/simplenote-macos/pull/764) to test this Pull Request.

Thanks in advance!!

### Release
These changes do not require release notes.
